### PR TITLE
Fix Concurrency link in docs

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -326,7 +326,7 @@ export interface MeldClone extends MeldStateMachine {
  * constraint requires to know the final state, it must infer it from the given
  * reader and the update.
  *
- * @see [m-ld concurrency](http://m-ld/org/doc/#concurrency)
+ * @see [m-ld concurrency](http://m-ld.org/doc/#concurrency)
  */
 export interface MeldConstraint {
   /**


### PR DESCRIPTION
Came across this and figured I should send back a fix. :)

I didn't mean to add an EOF line break, but apparently GitHub's editor does that. :/