### PR TITLE
Export `MeldIoConfig`

### DIFF
--- a/src/socket.io/index.ts
+++ b/src/socket.io/index.ts
@@ -1,1 +1,1 @@
-export { IoRemotes } from './IoRemotes';
+export { IoRemotes, MeldIoConfig } from './IoRemotes';


### PR DESCRIPTION
[The docs say](https://js.m-ld.org/#socketio-remotes):

> The `IoRemotes` class and its companion configuration class `MeldIoConfig` can be imported or required from `'@m-ld/m-ld/dist/socket.io'`. You must also install the [`socket.io-client`](https://www.npmjs.com/package/socket.io-client) package as a peer of `@m-ld/m-ld`.

but it looks like `MeldIoConfig` wasn't re-exported from the barrel module. This adds it.