### PR TITLE
Remove rogue backtick from example

### DIFF
--- a/src/jrql-support.ts
+++ b/src/jrql-support.ts
@@ -850,7 +850,7 @@ export interface Update extends Query {
    *
    * For example, assume this data exists:
    * ```json
-   * { "@id": "fred", "name": "Fred" }`
+   * { "@id": "fred", "name": "Fred" }
    * ```
    *
    * Compare the following update patterns:


### PR DESCRIPTION
Thanks for adding this behavior! I spotted a rogue backtick in the example; this'll remove it.