### PR TITLE
Added statute "prover" extension loading via "extension subjects"

### DIFF
--- a/compliance/test.js
+++ b/compliance/test.js
@@ -1,11 +1,10 @@
 const { fork } = require('child_process');
 const { createWriteStream } = require('fs');
-const { join } = require('path');
+const { dirname, join } = require('path');
 const inspector = require('inspector');
 const LOG = require('loglevel');
 
-const COMPLIANCE_DIR = '../node_modules/@m-ld/m-ld-spec/compliance'.split('/');
-const COMPLIANCE_PATH = join(__dirname, ...COMPLIANCE_DIR);
+const COMPLIANCE_PATH = dirname(require.resolve('@m-ld/m-ld-spec/compliance/jasmine.json'));
 const Jasmine = require(require.resolve('jasmine', { paths: [COMPLIANCE_PATH] }));
 const jasmine = new Jasmine();
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
+    "./dist/orm": "./dist/orm/index.js",
     "./dist/mqtt": "./dist/mqtt/index.js",
     "./dist/socket.io": "./dist/socket.io/index.js",
     "./dist/socket.io-server": "./dist/socket.io/server/index.js",

--- a/src/ably/AblyRemotes.ts
+++ b/src/ably/AblyRemotes.ts
@@ -41,7 +41,7 @@ export class AblyRemotes extends PubsubRemotes {
 
   constructor(
     config: MeldAblyConfig,
-    extensions: MeldExtensions,
+    extensions: () => Promise<MeldExtensions>,
     connect = ablyConnect
   ) {
     super(config, extensions);

--- a/src/ably/AblyWrtcRemotes.ts
+++ b/src/ably/AblyWrtcRemotes.ts
@@ -8,7 +8,7 @@ export class AblyWrtcRemotes extends AblyRemotes implements PeerSignaller {
 
   constructor(
     config: MeldAblyConfig & MeldWrtcConfig,
-    extensions: MeldExtensions,
+    extensions: () => Promise<MeldExtensions>,
     connect = ablyConnect
   ) {
     super(config, extensions, connect);

--- a/src/engine/CloneExtensions.ts
+++ b/src/engine/CloneExtensions.ts
@@ -1,24 +1,27 @@
 import {
-  ConstructMeldExtensions, MeldConstraint, MeldExtensions, MeldPreUpdate, MeldReadState
+  GraphSubject, MeldConstraint, MeldExtensions, MeldPreUpdate, MeldReadState, StateManaged
 } from '../api';
-import { Construct, Context, isList, List, Reference, Subject } from '../jrql-support';
+import { Context, Subject } from '../jrql-support';
 import { constraintFromConfig } from '../constraints';
 import { DefaultList } from '../constraints/DefaultList';
 import { InitialApp, MeldApp, MeldConfig } from '../config';
 import { M_LD } from '../ns';
 import { getIdLogger } from './util';
 import { Logger } from 'loglevel';
-import { firstValueFrom } from 'rxjs';
-import { updateSubject } from '../updates';
-import { castPropertyValue, propertyValue } from '../js-support';
+import { OrmDomain, OrmState, OrmSubject } from '../orm/index';
+import { ExtensionSubject } from '../orm';
 
 /**
  * Top-level aggregation of extensions. Created from the configuration and
  * runtime app initially; thereafter tracks extensions declared in the domain
  * data and installs them as required.
  */
-export class CloneExtensions implements MeldExtensions {
-  static async initial(config: MeldConfig, app: InitialApp, context: Context) {
+export class CloneExtensions extends OrmDomain implements StateManaged<MeldExtensions> {
+  static async initial(
+    config: MeldConfig,
+    app: InitialApp,
+    context: Context
+  ) {
     return new CloneExtensions({
       constraints: await this.constraintsFromConfig(config, app.constraints, context),
       transportSecurity: app.transportSecurity
@@ -35,117 +38,131 @@ export class CloneExtensions implements MeldExtensions {
       .map(item => constraintFromConfig(item, context))));
   }
 
-  private log: Logger;
-  private extensionDefList: List & Reference = { '@id': M_LD.extensions, '@list': [] };
+  private readonly log: Logger;
+  /** Represents the `@list` of the global `M_LD.extensions` list subject  */
+  private readonly extensionSubjects: ManagedExtensionSubject[];
+
+  ready = () => this.upToDate().then(() => {
+    const id = this.config['@id'];
+    return Promise.all(this.extensions()).then(extensions => ({
+      get constraints() {
+        return constraints(extensions, id);
+      },
+      get agreementConditions() {
+        return agreementConditions(extensions);
+      },
+      get transportSecurity() {
+        return transportSecurity(extensions);
+      }
+    }));
+  });
 
   private constructor(
-    private initial: MeldExtensions,
-    private config: MeldConfig,
-    private app: MeldApp
+    private readonly initial: MeldExtensions,
+    private readonly config: MeldConfig,
+    private readonly app: MeldApp
   ) {
+    super();
     this.log = getIdLogger(this.constructor, config['@id'], config.logLevel);
-  }
-
-  get constraints() {
-    return this._constraints();
-  }
-
-  private *_constraints() {
-    let foundDefaultList = false;
-    for (let ext of this.extensions()) {
-      for (let constraint of ext.constraints ?? []) {
-        yield constraint;
-        foundDefaultList ||= constraint instanceof DefaultList;
-      }
-    }
-    // Ensure the default list constraint exists
-    if (!foundDefaultList)
-      yield new DefaultList(this.config['@id']);
-  }
-
-  get agreementConditions() {
-    return this._agreementConditions();
-  }
-
-  private *_agreementConditions() {
-    for (let ext of this.extensions())
-      yield *ext.agreementConditions ?? [];
-  }
-
-  get transportSecurity() {
-    for (let ext of this.extensions())
-      if (ext.transportSecurity != null)
-        return ext.transportSecurity;
+    this.extensionSubjects = [];
   }
 
   async initialise(state: MeldReadState) {
-    // Load data-declared extensions
-    const defList = await firstValueFrom(state.read<Construct>({
-      '@construct': {
-        '@id': M_LD.extensions,
-        '@list': {
-          '?': { // Variable index means load all indexes
-            '@id': '?',
-            '@type': M_LD.JS.commonJsModule,
-            [M_LD.JS.require]: '?',
-            [M_LD.JS.className]: '?'
-          }
-        }
-      }
-    }), { defaultValue: undefined });
-    if (defList != null) {
-      if (isList(defList))
-        this.extensionDefList = defList;
-      else
-        this.log.warn(`${M_LD.extensions} is not a List: no extensions loaded`);
-      // Instantiate the declared extensions
-      this.instantiateNewModules();
-    }
-    // Now initialise all extensions
-    for (let ext of this.extensions())
-      await ext.initialise?.(state);
+    await this.updating(state, async orm => {
+      // Load the top-level extensions subject into our cache
+      await this.loadExtensions(orm);
+      await orm.update();
+      // Now initialise all extensions
+      for (let extSubject of this.extensionSubjects)
+        await extSubject.initialiseOrUpdate(state);
+    });
   }
 
   async onUpdate(update: MeldPreUpdate, state: MeldReadState) {
-    // Capture any changes to the extensions
-    updateSubject(this.extensionDefList, update);
-    // Instantiate any new declared extensions, permissively
-    // TODO: check for changed modules, not just new ones
-    this.instantiateNewModules({ permissive: true });
-    // Update the extensions themselves
-    for (let ext of this.extensions())
-      await ext.onUpdate?.(update, state);
+    await this.updating(state, async orm => {
+      // This will update the extension list and all the extension subjects
+      await orm.update(update, deleted => {
+        if (deleted.src['@id'] === M_LD.extensions)
+          // The whole extensions object has been deleted!
+          this.extensionSubjects.length = 0;
+      }, async insert => {
+        // This catches the case there were no extensions in the initialise
+        if (insert['@id'] === M_LD.extensions)
+          // OrmSubject cannot cope with list update syntax, so load from state
+          await this.loadExtensions(orm);
+      });
+      // Update or initialise the extensions themselves
+      for (let extSubject of this.extensionSubjects)
+        await extSubject.initialiseOrUpdate(state, update);
+    });
   }
 
-  private instantiateNewModules({ permissive }: { permissive?: true } = {}) {
-    for (let cjsModuleDef of this.extCjsModuleDefs) {
-      if (cjsModuleDef.__instance == null) {
-        try {
-          const cjsModule = propertyValue(cjsModuleDef, M_LD.JS.require, String);
-          const className = propertyValue(cjsModuleDef, M_LD.JS.className, String);
-          const construct: ConstructMeldExtensions = require(cjsModule)[className];
-          cjsModuleDef.__instance = <any>new construct(this.config, this.app);
-          this.log.info(`Installed extension ${cjsModuleDef['@id']}`);
-        } catch (e) {
-          if (permissive) {
-            this.log.warn(`CommonJS module ${cjsModuleDef[M_LD.JS.require]} ` +
-              `class ${cjsModuleDef[M_LD.JS.className]} cannot be instantiated`, e);
-            cjsModuleDef.__instance = {};
-          } else {
-            throw e;
-          }
+  private loadExtensions(orm: OrmState) {
+    return orm.get({ '@id': M_LD.extensions }, src => {
+      const { config, app, extensionSubjects } = this;
+      return new class extends OrmSubject {
+        constructor(src: GraphSubject) {
+          super(src);
+          this.initList(src, Subject, extensionSubjects,
+            i => extensionSubjects[i].src,
+            async (i, v: GraphSubject) => extensionSubjects[i] = await orm.get(v,
+              src => new ManagedExtensionSubject(src, { config, app })));
         }
-      }
-    }
-  }
-
-  private get extCjsModuleDefs() {
-    return castPropertyValue(this.extensionDefList, Array, Subject);
+      }(src);
+    });
   }
 
   private *extensions() {
     yield this.initial;
-    for (let cjsModule of this.extCjsModuleDefs)
-      yield (cjsModule.__instance ?? {}) as MeldExtensions;
+    for (let extSubject of this.extensionSubjects)
+      if (extSubject.instance != null)
+        yield extSubject.instance.ready();
   }
+}
+
+class ManagedExtensionSubject extends ExtensionSubject<StateManaged<MeldExtensions>> {
+  private initialised = false;
+
+  protected setUpdated(result: unknown | Promise<unknown>) {
+    this.initialised = false;
+    super.setUpdated(result);
+  }
+
+  async initialiseOrUpdate(state: MeldReadState, update?: MeldPreUpdate) {
+    if (!this.initialised) {
+      await this.instance.initialise?.(state);
+      this.initialised = true;
+    } else if (update != null) {
+      await this.instance.onUpdate?.(update, state);
+    } else {
+      throw new Error('No update available');
+    }
+  }
+}
+
+function *constraints(
+  extensions: Iterable<MeldExtensions>,
+  id: string
+) {
+  let foundDefaultList = false;
+  for (let ext of extensions) {
+    for (let constraint of ext.constraints ?? []) {
+      yield constraint;
+      foundDefaultList ||= constraint instanceof DefaultList;
+    }
+  }
+  // Ensure the default list constraint exists
+  if (!foundDefaultList)
+    yield new DefaultList(id);
+}
+
+function *agreementConditions(extensions: Iterable<MeldExtensions>) {
+  for (let ext of extensions)
+    yield *ext.agreementConditions ?? [];
+}
+
+function transportSecurity(extensions: Awaited<MeldExtensions>[]) {
+  for (let ext of extensions)
+    if (ext.transportSecurity != null)
+      return ext.transportSecurity;
 }

--- a/src/engine/SubjectQuads.ts
+++ b/src/engine/SubjectQuads.ts
@@ -42,7 +42,7 @@ export class SubjectQuads {
           this.objectTerm(value, property));
       // TODO: What if the property expands to a keyword in the context?
       else
-        throw new Error('Cannot yield quad from top-level value');
+        throw new Error(`Cannot yield quad from top-level value: ${value}`);
   }
 
   private *subjectQuads(

--- a/src/engine/dataset/DatasetEngine.ts
+++ b/src/engine/dataset/DatasetEngine.ts
@@ -1,5 +1,5 @@
 import {
-  GraphSubject, LiveStatus, MeldExtensions, MeldReadState, MeldStatus, StateProc
+  GraphSubject, LiveStatus, MeldExtensions, MeldReadState, MeldStatus, StateManaged, StateProc
 } from '../../api';
 import { MeldLocal, MeldRemotes, OperationMessage, Recovery, Revup, Snapshot } from '..';
 import { liveRollup } from '../LiveValue';
@@ -44,7 +44,7 @@ enum OperationOutcome {
 export type DatasetEngineParameters = {
   dataset: Dataset;
   remotes: MeldRemotes;
-  extensions: MeldExtensions;
+  extensions: StateManaged<MeldExtensions>;
   config: MeldConfig;
   app: MeldApp;
   context?: Context;

--- a/src/engine/jrql-util.ts
+++ b/src/engine/jrql-util.ts
@@ -33,8 +33,8 @@ export type JrqlMode = 'match' | 'load' | 'graph';
  * is the variable name.
  */
 export function *listItems(
-  list: SubjectPropertyObject, mode: JrqlMode = 'graph'):
-  IterableIterator<[ListIndex | string, SubjectPropertyObject]> {
+  list: SubjectPropertyObject, mode: JrqlMode = 'graph'
+): IterableIterator<[ListIndex | string, SubjectPropertyObject]> {
   if (typeof list === 'object') {
     // This handles arrays as well as hashes
     for (let [indexKey, item] of Object.entries(list)) {
@@ -58,8 +58,10 @@ export function *listItems(
 }
 
 function *subItems(
-  list: SubjectPropertyObject, index: ListIndex, item: SubjectPropertyObject):
-  IterableIterator<[ListIndex, SubjectPropertyObject]> {
+  list: SubjectPropertyObject,
+  index: ListIndex,
+  item: SubjectPropertyObject
+): IterableIterator<[ListIndex, SubjectPropertyObject]> {
   const [topIndex, subIndex] = index;
   if (subIndex == null && isArray(item) && !isArray(list))
     // Object.entries skips empty array positions
@@ -77,7 +79,9 @@ function *subItems(
  * sub-index is always an array if present
  */
 export function addPropertyObject(
-  subject: Subject, property: SubjectProperty, object: Value,
+  subject: Subject,
+  property: SubjectProperty,
+  object: Value,
   createList: () => object = () => ({})
 ): Subject {
   if (typeof property == 'string') {

--- a/src/engine/jsonld.ts
+++ b/src/engine/jsonld.ts
@@ -4,6 +4,8 @@ import { compactIri as _compactIri } from 'jsonld/lib/compact';
 import { compareValues as _compareValues } from 'jsonld/lib/util';
 import { ActiveContext, expandIri, getInitialContext } from 'jsonld/lib/context';
 import { isAbsolute } from 'jsonld/lib/url';
+import { isSet } from '../jrql-support';
+import { array } from '../util';
 
 export { hasProperty, hasValue } from 'jsonld/lib/util';
 export { ActiveContext, getContextValue } from 'jsonld/lib/context';
@@ -61,11 +63,22 @@ export async function nextCtx(ctx: ActiveContext, context?: Context,
  *
  * @param subject the subject.
  * @param property the property.
- *
  * @return all of the values for a subject's property as an array.
  */
 export function getValues(subject: { [key: string]: any }, property: string): Array<any> {
-  return [].concat(subject[property] ?? []);
+  return asValues(subject[property]);
+}
+
+/**
+ * Normalises the value of a JSON-LD object entry to an array of values.
+ *
+ * Note that Lists are treated as Subjects.
+ *
+ * @param value the value.
+ * @return the value as an array of values.
+ */
+export function asValues(value: any) {
+  return value == null ? [] : array(isSet(value) ? value['@set'] : value);
 }
 
 export function canonicalDouble(value: number) {

--- a/src/jrql-support.ts
+++ b/src/jrql-support.ts
@@ -210,13 +210,21 @@ export function isValueObject(value: SubjectPropertyObject): value is ValueObjec
 }
 
 /** @internal */
+function isUnaryObject(value: SubjectPropertyObject, theKey: string) {
+  return value != null && typeof value == 'object'
+    && theKey in value
+    && Object.entries(value).every(
+      ([key, value]) => key === theKey || value === undefined);
+}
+
+/** @internal */
 export function isReference(value: SubjectPropertyObject): value is Reference {
-  return typeof value == 'object' && '@id' in value && Object.keys(value).length == 1;
+  return isUnaryObject(value, '@id');
 }
 
 /** @internal */
 export function isVocabReference(value: SubjectPropertyObject): value is VocabReference {
-  return typeof value == 'object' && '@vocab' in value && Object.keys(value).length == 1;
+  return isUnaryObject(value, '@vocab');
 }
 
 /**
@@ -316,8 +324,10 @@ export type SubjectProperty =
  * @param object the object (value) of the property
  * @category json-rql
  */
-export function isPropertyObject(property: string, object: Subject['any']):
-  object is SubjectPropertyObject {
+export function isPropertyObject(
+  property: string,
+  object: Subject['any']
+): object is SubjectPropertyObject {
   return property !== '@context' && property !== '@id' && object != null;
 }
 

--- a/src/js-support.ts
+++ b/src/js-support.ts
@@ -2,10 +2,9 @@ import {
   isList, isPropertyObject, isReference, isSet, isValueObject, isVocabReference, Reference, Subject,
   SubjectPropertyObject, Value, VocabReference
 } from './jrql-support';
-import { array } from './util';
 import { isArray } from './engine/util';
 import { XS } from './ns';
-import { isAbsolute } from './engine/jsonld';
+import { asValues, isAbsolute } from './engine/jsonld';
 
 export type JsAtomValueConstructor =
   typeof String |
@@ -52,7 +51,7 @@ type OptionalConstructed<S> =
         S | undefined;
 
 /** @internal */
-export type ValueConstructed<T, S> =
+export type ValueConstructed<T, S = unknown> =
   T extends String ? string :
     T extends Number ? number :
       T extends Boolean ? boolean :
@@ -177,16 +176,14 @@ export function castPropertyValue<T, S>(
 }
 
 /**@internal*/
-function valueAsArray(value: SubjectPropertyObject) {
-  if (isSet(value)) {
-    return array(value['@set']);
-  } else if (isList(value)) {
+export function valueAsArray(value: SubjectPropertyObject) {
+  if (isList(value)) {
     if (isArray(value['@list']))
       return value['@list'];
     else
       return Object.assign([], value['@list']);
   } else {
-    return array(value);
+    return asValues(value);
   }
 }
 
@@ -274,7 +271,7 @@ function castValue<T>(value: Value, type: JsAtomValueConstructor): T {
  * JSON-LD value suitable for use in a {@link Subject}.
  */
 export function normaliseValue(
-  value: ValueConstructed<unknown, unknown>
+  value: ValueConstructed<unknown>
 ): SubjectPropertyObject | undefined {
   if (isArray(value))
     return value.map(v => normaliseAtomValue(v));
@@ -288,7 +285,7 @@ export function normaliseValue(
 
 /**@internal*/
 function normaliseAtomValue(
-  value: ValueConstructed<unknown, unknown>
+  value: ValueConstructed<unknown>
 ): SubjectPropertyObject {
   switch (typeof value) {
     case 'string':

--- a/src/mqtt/MqttRemotes.ts
+++ b/src/mqtt/MqttRemotes.ts
@@ -47,7 +47,11 @@ export class MqttRemotes extends PubsubRemotes {
   private readonly replyTopic: MqttTopic<ReplyParams & TopicParams>;
   private readonly presence: MqttPresence;
 
-  constructor(config: MeldMqttConfig, extensions: MeldExtensions, connect = defaultConnect) {
+  constructor(
+    config: MeldMqttConfig,
+    extensions: () => Promise<MeldExtensions>,
+    connect = defaultConnect
+  ) {
     super(config, extensions);
 
     const { id, domain } = this;

--- a/src/orm/ExtensionSubject.ts
+++ b/src/orm/ExtensionSubject.ts
@@ -1,0 +1,63 @@
+import { OrmSubject } from './OrmSubject';
+import { GraphSubject } from '../api';
+import { M_LD } from '../ns';
+import { Optional } from '../js-support';
+import { MeldApp, MeldConfig } from '../config';
+
+export type ExtensionInstanceConstructor<T> = { new(subject: ExtensionSubject<T>): T };
+export type ExtensionEnvironment = { readonly config: MeldConfig, readonly app: MeldApp };
+
+export class ExtensionSubject<T> extends OrmSubject {
+  moduleType: string[];
+  cjsModule: string | undefined;
+  className: string;
+  private _instance?: T;
+  /** ERR_MODULE_NOT_FOUND or any constructor errors */
+  private _loadErr: any;
+
+  // noinspection JSUnusedGlobalSymbols – env is part of the interface
+  constructor(
+    src: GraphSubject,
+    readonly env: ExtensionEnvironment
+  ) {
+    super(src);
+    this.initSrcProperty(src, '@type', [Array, String],
+      () => this.moduleType, v => this.moduleType = v);
+    this.initSrcProperty(src, M_LD.JS.require, [Optional, String],
+      () => this.cjsModule, v => this.cjsModule = v);
+    this.initSrcProperty(src, M_LD.JS.className, String,
+      () => this.className, v => this.className = v);
+  }
+
+  /**
+   * The loaded class instance. Only call this after updates have been applied.
+   * @see OrmSubject.updated
+   */
+  get instance(): T {
+    if (this._instance == null && this._loadErr == null) {
+      if (!this.moduleType.includes(M_LD.JS.commonJsModule)) {
+        this._loadErr = `${this.src['@id']}: Extension type ${this.moduleType} not supported.`;
+      } else if (this.cjsModule == null) {
+        this._loadErr = `${this.src['@id']}: CommonJS module declared with no id.`;
+      } else {
+        try {
+          const Instance: ExtensionInstanceConstructor<T> =
+            require(this.cjsModule)[this.className];
+          this._instance = new Instance(this);
+        } catch (e) {
+          this._loadErr = e;
+        }
+      }
+    }
+    if (this._loadErr != null)
+      throw this._loadErr;
+    else
+      return this._instance!;
+  }
+
+  protected setUpdated(result: unknown | Promise<unknown>) {
+    delete this._instance;
+    delete this._loadErr;
+    super.setUpdated(result);
+  }
+}

--- a/src/orm/OrmSubject.ts
+++ b/src/orm/OrmSubject.ts
@@ -1,0 +1,136 @@
+import { isPropertyObject, Reference, Subject } from '../jrql-support';
+import { GraphSubject } from '../api';
+import {
+  AtomType, castPropertyValue, ContainerType, normaliseValue, ValueConstructed
+} from '../js-support';
+import { isArray, isNaturalNumber } from '../engine/util';
+import { asValues } from '../engine/jsonld';
+
+/**
+ * TODO docs, unit tests
+ *
+ * @experimental
+ * @category Experimental
+ */
+export abstract class OrmSubject {
+  readonly src: Subject & Reference;
+  private readonly propertiesInState = new Set<string>();
+  updated: Promise<this>;
+
+  protected constructor(src: GraphSubject) {
+    this.src = { '@id': src['@id'] };
+    this.updated = Promise.resolve(this);
+  }
+
+  get deleted() {
+    return this.propertiesInState.size === 0;
+  }
+
+  /**
+   * @param src the initial graph subject – only used for its property value
+   * @param property the property IRI in context
+   * @param type the expected type of the property. If the type in the graph
+   * cannot be cast to this type, {@link updated} will be rejected.
+   * @param get called to get the value of the property
+   * @param set called to set the value of the property
+   * @param initValue an initial Javascript value. If this is non-null, it will
+   * be used instead of the `src` property value.
+   * @public because the structure of this ORM subject may not necessarily
+   * reflect the graph representation – for example, an aggregation member may
+   * represent data from its parent graph subject.
+   */
+  initSrcProperty<T, S>(
+    src: GraphSubject,
+    property: string,
+    type: AtomType<T> | [ContainerType<T>, AtomType<S>],
+    get: () => ValueConstructed<T, S>,
+    set: (v: ValueConstructed<T, S>) => unknown | Promise<unknown>,
+    initValue?: ValueConstructed<T, S>
+  ) {
+    const [topType, subType] = isArray(type) ? type : [type];
+    Object.defineProperty(this.src, property, {
+      get,
+      set: v => {
+        this.propertiesInState[asValues(v).length > 0 ? 'add' : 'delete'](property);
+        try {
+          const value = castPropertyValue(v, topType, subType, property);
+          this.setUpdated(set(value));
+        } catch (e) {
+          this.setUpdated(Promise.reject(e));
+        }
+      },
+      enumerable: true, // JSON-able
+      configurable: false // Cannot delete the property
+    });
+    if (initValue != null)
+      this.setUpdated(set(initValue));
+    else
+      this.src[property] = src[property]; // Invokes the setter
+  }
+
+  /**
+   * @param src a List graph subject to initialise the list from
+   * @param type JSON-LD type of items in the list
+   * @param list an array-like object having:
+   * 1. a _mutable_ length, which will be set during list updates
+   * 2. numeric indexes, which will only be used to query for existence
+   * @param get will be called to get JSON-LD values for items in the list
+   * @param set will be called to set items in the list with JSON-LD values
+   */
+  initList<T>(
+    src: GraphSubject,
+    type: AtomType<T>,
+    list: { length: number, readonly [i: number]: unknown },
+    get: (i: number) => ValueConstructed<T>,
+    set: (i: number, v: ValueConstructed<T>) => unknown | Promise<unknown>
+  ) {
+    // Source list is an array-like proxy
+    // @ts-ignore
+    this.src['@list'] = new Proxy(list, {
+      ownKeys: list => Object.keys(list).filter(k => withArrayLikeKey(k,
+        () => true, () => true, false)),
+      has: (list, p: string | symbol) => withArrayLikeKey(p,
+        () => true, () => true, false),
+      get: (list, p: string | symbol) => withArrayLikeKey(p,
+        () => list.length, i => i in list ?
+          normaliseValue(get(i)) : undefined, undefined),
+      set: (list, p: string | symbol, value: any) => withArrayLikeKey(p, () => {
+        list.length = value;
+        this.propertiesInState[list.length > 0 ? 'add' : 'delete']('@list');
+        return true;
+      }, i => {
+        this.setUpdated(set(i, castPropertyValue(value, type)));
+        return true;
+      }, false)
+    });
+    if (isPropertyObject('@list', src['@list']))
+      [].splice.call(this.src['@list'], 0, list.length, ...asValues(src['@list']));
+  }
+
+  /**
+   * Called when a property is changing.
+   *
+   * @param result If any property is asynchronously updated, the final value
+   * will only be definitively set when this promise resolves.
+   */
+  protected setUpdated(result: unknown | Promise<unknown>) {
+    this.updated = Promise.all([this.updated, result]).then(() => this);
+    this.updated.catch(() => {}); // Prevents unhandled rejection
+  }
+}
+
+function withArrayLikeKey<T>(
+  key: string | symbol,
+  withLength: () => T,
+  withIndex: (i: number) => T,
+  def: T
+) {
+  if (key === 'length') {
+    return withLength();
+  } else if (typeof key != 'symbol') {
+    const i = Number(key);
+    if (isNaturalNumber(i))
+      return withIndex(i);
+  }
+  return def;
+}

--- a/src/orm/index.ts
+++ b/src/orm/index.ts
@@ -1,0 +1,4 @@
+export { OrmSubject } from './OrmSubject';
+export { OrmDomain, OrmState } from './OrmDomain';
+export { ExtensionSubject, ExtensionEnvironment } from './ExtensionSubject';
+

--- a/src/security/MeldAclTransportSecurity.ts
+++ b/src/security/MeldAclTransportSecurity.ts
@@ -39,12 +39,12 @@ export class MeldAclTransportSecurity implements MeldTransportSecurity {
    * @param aesKey a raw AES key, e.g. `randomBytes(32)`
    */
   static declareSecret = (domainName: string, aesKey: Buffer): Write => ({
-      '@id': `http://${domainName}/`,
-      [M_LD.secret]: {
-        '@type': XS.base64Binary,
-        '@value': `${aesKey.toString('base64')}`
-      }
-    });
+    '@id': `http://${domainName}/`,
+    [M_LD.secret]: {
+      '@type': XS.base64Binary,
+      '@value': `${aesKey.toString('base64')}`
+    }
+  });
 
   /**
    * Use to register each principal with access to the domain, for example

--- a/src/socket.io/IoRemotes.ts
+++ b/src/socket.io/IoRemotes.ts
@@ -21,7 +21,11 @@ export interface MeldIoConfig extends MeldConfig {
 export class IoRemotes extends PubsubRemotes {
   private readonly socket: Socket;
 
-  constructor(config: MeldIoConfig, extensions: MeldExtensions, connect = io) {
+  constructor(
+    config: MeldIoConfig,
+    extensions: () => Promise<MeldExtensions>,
+    connect = io
+  ) {
     super(config, extensions);
     const opts = config.io?.opts;
     const optsToUse: Partial<ManagerOptions> = {

--- a/src/subjects.ts
+++ b/src/subjects.ts
@@ -1,11 +1,16 @@
 import { isPropertyObject, isSet, Reference, Subject, Value } from './jrql-support';
 import { isArray } from './engine/util';
 import { compareValues, getValues, hasProperty, hasValue } from './engine/jsonld';
-import { array } from './util';
 
-/** @internal */
+export { compareValues, getValues };
+
+/**
+ * @internal
+ * @todo A `@list` property is a property according to `isPropertyObject` but
+ * should have very different behaviour
+ */
 export class SubjectPropertyValues {
-  private readonly wasArray: boolean;
+  private readonly prior: 'atom' | 'array' | 'set';
   private readonly configurable: boolean;
 
   constructor(
@@ -13,24 +18,54 @@ export class SubjectPropertyValues {
     readonly property: string,
     readonly deepUpdater?: (values: Iterable<any>) => void
   ) {
-    this.wasArray = isArray(this.subject[this.property]);
+    const object = this.subject[this.property];
+    if (isArray(object))
+      this.prior = 'array';
+    else if (isPropertyObject(this.property, object) && isSet(object))
+      this.prior = 'set';
+    else
+      this.prior = 'atom';
     this.configurable = Object.getOwnPropertyDescriptor(subject, property)?.configurable ?? false;
   }
 
+  get values() {
+    return getValues(this.subject, this.property);
+  }
+
   insert(...values: any[]) {
-    const object = this.subject[this.property];
-    if (isPropertyObject(this.property, object) && isSet(object))
-      object['@set'] = SubjectPropertyValues.union(array(object['@set']), values);
-    else
-      this.setValues(SubjectPropertyValues.union(this.getValues(), values));
+    this.update([], values);
   }
 
   delete(...values: any[]) {
-    this.setValues(SubjectPropertyValues.minus(this.getValues(), values));
+    this.update(values, []);
   }
 
-  exists(value?: any) {
-    if (value != null) {
+  update(deletes: any[], inserts: any[]) {
+    const oldValues = this.values;
+    let values = SubjectPropertyValues.minus(oldValues, deletes);
+    values = SubjectPropertyValues.union(values, inserts);
+    // Apply deep updates to the final values
+    this.deepUpdater?.(values);
+    // Do not call setter if nothing has changed
+    if (oldValues !== values) {
+      if (this.prior == 'set') {
+        // A JSON-LD Set cannot have any other key than @set
+        this.subject[this.property] = { '@set': values };
+      } else {
+        // Per contract of updateSubject, this always L-value assigns (no pushing)
+        this.subject[this.property] = values.length === 0 ? [] : // See next
+          // Properties which were not an array before get collapsed
+          values.length === 1 && this.prior == 'atom' ? values[0] : values;
+        if (values.length === 0 && this.configurable)
+          delete this.subject[this.property];
+      }
+    }
+  }
+
+  exists(value?: any): boolean {
+    if (isArray(value)) {
+      return value.every(v => this.exists(v));
+    } else if (value != null) {
       const object = this.subject[this.property];
       if (!isPropertyObject(this.property, object))
         return false;
@@ -43,28 +78,19 @@ export class SubjectPropertyValues {
     }
   }
 
-  private getValues() {
-    return getValues(this.subject, this.property);
-  }
-
-  private setValues(values: any[]) {
-    // Apply deep updates to the final values
-    this.deepUpdater?.(values);
-    // Per contract of updateSubject, this always L-value assigns (no pushing)
-    this.subject[this.property] = values.length === 0 ? [] : // See next
-      // Properties which were not an array before get collapsed
-      values.length === 1 && !this.wasArray ? values[0] : values;
-    if (values.length === 0 && this.configurable)
-      delete this.subject[this.property];
-  }
-
+  /** @returns `values` if nothing has changed */
   private static union(values: any[], unionValues: any[]): any[] {
-    return values.concat(SubjectPropertyValues.minus(unionValues, values));
+    const newValues = SubjectPropertyValues.minus(unionValues, values);
+    return newValues.length > 0 ? values.concat(newValues) : values;
   }
 
+  /** @returns `values` if nothing has changed */
   private static minus(values: any[], minusValues: any[]): any[] {
-    return values.filter(value => !minusValues.some(
+    if (values.length === 0 || minusValues.length === 0)
+      return values;
+    const filtered = values.filter(value => !minusValues.some(
       minusValue => compareValues(value, minusValue)));
+    return filtered.length === values.length ? values : filtered;
   }
 }
 
@@ -77,7 +103,11 @@ export class SubjectPropertyValues {
  * @param values the value to add.
  * @category Utility
  */
-export function includeValues(subject: Subject, property: string, ...values: Value[]) {
+export function includeValues(
+  subject: Subject,
+  property: string,
+  ...values: Value[]
+) {
   new SubjectPropertyValues(subject, property).insert(...values);
 }
 
@@ -88,10 +118,14 @@ export function includeValues(subject: Subject, property: string, ...values: Val
  *
  * @param subject the subject to inspect
  * @param property the property to inspect
- * @param value the value to find in the set. If `undefined`, then wildcard
- * checks for any value at all.
+ * @param value the value or values to find in the set. If `undefined`, then
+ * wildcard checks for any value at all. If an empty array, always returns `true`
  * @category Utility
  */
-export function includesValue(subject: Subject, property: string, value?: Value): boolean {
+export function includesValue(
+  subject: Subject,
+  property: string,
+  value?: Value | Value[]
+): boolean {
   return new SubjectPropertyValues(subject, property).exists(value);
 }

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -154,8 +154,9 @@ export class SubjectUpdater {
             break;
           default:
             const subjectProperty = new SubjectPropertyValues(subject, property, this.updateValues);
-            subjectProperty.delete(...getValues(deletes ?? {}, property));
-            subjectProperty.insert(...getValues(inserts ?? {}, property));
+            subjectProperty.update(
+              getValues(deletes ?? {}, property),
+              getValues(inserts ?? {}, property));
         }
       }
     }
@@ -171,10 +172,11 @@ export class SubjectUpdater {
 
   private updateList(subject: GraphSubject, deletes?: GraphSubject, inserts?: GraphSubject) {
     if (isList(subject)) {
-      if (isListUpdate(deletes) || isListUpdate(inserts))
+      if (isListUpdate(deletes) || isListUpdate(inserts)) {
         this.updateListIndexes(subject['@list'],
           isListUpdate(deletes) ? deletes['@list'] : {},
           isListUpdate(inserts) ? inserts['@list'] : {});
+      }
       this.updateValues(array(subject['@list']));
     }
   }
@@ -182,8 +184,10 @@ export class SubjectUpdater {
   private updateListIndexes(list: List['@list'], deletes: List['@list'], inserts: List['@list']) {
     const splice = typeof list.splice == 'function' ? list.splice : (() => {
       // Array splice operation must have a length field to behave
-      const maxIndex = Math.max(...Object.keys(list).map(Number).filter(isNaturalNumber));
-      list.length = isFinite(maxIndex) ? maxIndex + 1 : 0;
+      if (!('length' in list)) {
+        const maxIndex = Math.max(...Object.keys(list).map(Number).filter(isNaturalNumber));
+        list.length = isFinite(maxIndex) ? maxIndex + 1 : 0;
+      }
       return [].splice;
     })();
     const splices: { deleteCount: number, items?: any[] }[] = []; // Sparse

--- a/test/DatasetEngine.test.ts
+++ b/test/DatasetEngine.test.ts
@@ -1,5 +1,7 @@
 import { DatasetEngine, DatasetEngineParameters } from '../src/engine/dataset/DatasetEngine';
-import { hotLive, memStore, MockProcess, mockRemotes, testConfig } from './testClones';
+import {
+  hotLive, memStore, MockProcess, mockRemotes, testConfig, testExtensions
+} from './testClones';
 import {
   asapScheduler, BehaviorSubject, EMPTY, EmptyError, firstValueFrom, NEVER, of, Subject as Source,
   throwError
@@ -8,22 +10,25 @@ import { comesAlive } from '../src/engine/AbstractMeld';
 import { count, map, observeOn, take, toArray } from 'rxjs/operators';
 import { TreeClock } from '../src/engine/clocks';
 import { MeldRemotes, OperationMessage, Snapshot } from '../src/engine';
-import { Describe, GraphSubject, MeldConfig, MeldReadState, Read, Subject, Update } from '../src';
+import {
+  Describe, GraphSubject, MeldConfig, MeldReadState, Read, Subject, Update, Write
+} from '../src';
 import { AbstractLevelDOWN } from 'abstract-leveldown';
 import { jsonify } from './testUtil';
 import { MeldMemDown } from '../src/memdown';
-import { Write } from '../src/jrql-support';
 import { Consumable } from 'rx-flowable';
 import { inflateFrom } from '../src/engine/util';
 import { MeldError } from '../src/engine/MeldError';
 import { Dataset } from '../src/engine/dataset/index';
 
 describe('Dataset engine', () => {
+  const extensions = testExtensions();
+
   describe('as genesis', () => {
     async function genesis(
       remotes: MeldRemotes, config?: Partial<MeldConfig>): Promise<DatasetEngine> {
       let clone = new DatasetEngine({
-        dataset: await memStore(), remotes, extensions: {}, app: {}, config: testConfig(config)
+        dataset: await memStore(), remotes, extensions, app: {}, config: testConfig(config)
       });
       await clone.initialise();
       return clone;
@@ -60,7 +65,7 @@ describe('Dataset engine', () => {
       super({
         dataset: params?.dataset ?? dataset,
         remotes: params?.remotes ?? mockRemotes(),
-        extensions: params?.extensions ?? {},
+        extensions: params?.extensions ?? extensions,
         config: params?.config ?? testConfig(),
         app: params?.app ?? {},
         context: params?.context
@@ -251,7 +256,7 @@ describe('Dataset engine', () => {
 
     test('initialises from snapshot', async () => {
       const clone = new DatasetEngine({
-        dataset: await memStore(), remotes, extensions: {}, app: {},
+        dataset: await memStore(), remotes, extensions, app: {},
         config: testConfig({ genesis: false })
       });
       await clone.initialise();
@@ -261,7 +266,7 @@ describe('Dataset engine', () => {
 
     test('can become a silo', async () => {
       const clone = new DatasetEngine({
-        dataset: await memStore(), remotes, extensions: {}, app: {},
+        dataset: await memStore(), remotes, extensions, app: {},
         config: testConfig({ genesis: false })
       });
       await clone.initialise();
@@ -295,7 +300,7 @@ describe('Dataset engine', () => {
       let clone = new DatasetEngine({
         dataset: await memStore({ backend }),
         remotes: mockRemotes(),
-        extensions: {},
+        extensions,
         app: {},
         config
       });
@@ -312,7 +317,7 @@ describe('Dataset engine', () => {
       const clone = new DatasetEngine({
         dataset: await memStore({ backend }),
         remotes,
-        extensions: {},
+        extensions,
         app: {},
         config: testConfig()
       });
@@ -333,7 +338,7 @@ describe('Dataset engine', () => {
       const clone = new DatasetEngine({
         dataset: await memStore({ backend }),
         remotes,
-        extensions: {},
+        extensions,
         app: {},
         config: testConfig()
       });
@@ -353,7 +358,7 @@ describe('Dataset engine', () => {
       const clone = new DatasetEngine({
         dataset: await memStore({ backend }),
         remotes,
-        extensions: {},
+        extensions,
         app: {},
         config: testConfig()
       });
@@ -377,7 +382,7 @@ describe('Dataset engine', () => {
       const clone = new DatasetEngine({
         dataset: await memStore({ backend }),
         remotes,
-        extensions: {},
+        extensions,
         app: {},
         config: testConfig()
       });
@@ -401,7 +406,7 @@ describe('Dataset engine', () => {
       const clone = new DatasetEngine({
         dataset: await memStore({ backend }),
         remotes,
-        extensions: {},
+        extensions,
         app: {},
         config: testConfig()
       });
@@ -457,7 +462,7 @@ describe('Dataset engine', () => {
       const clone = new DatasetEngine({
         dataset: await memStore({ backend }),
         remotes,
-        extensions: {},
+        extensions,
         app: {},
         config: testConfig()
       });

--- a/test/IoRemotes.test.ts
+++ b/test/IoRemotes.test.ts
@@ -15,6 +15,7 @@ describe('Socket.io Remotes', () => {
   let localRemotes: IoRemotes;
   let domain: string;
   let port: number;
+  const extensions = () => Promise.resolve({});
 
   beforeAll(done => {
     const server = createServer();
@@ -30,11 +31,11 @@ describe('Socket.io Remotes', () => {
   });
 
   beforeEach(() => {
-    domain = `${(expect.getState().currentTestName.replace(/[^\w]/g, ''))}.m-ld.org`;
+    domain = `${(expect.getState().currentTestName.replace(/\W/g, ''))}.m-ld.org`;
     remoteRemotes = new IoRemotes({
       '@id': 'remote-remotes', '@domain': domain, genesis: true,
       io: { uri: `http://localhost:${port}` }
-    }, {});
+    }, extensions);
   });
 
   test('remote connects', async () => {
@@ -50,7 +51,7 @@ describe('Socket.io Remotes', () => {
     localRemotes = new IoRemotes({
       '@id': 'local-remotes', '@domain': domain, genesis: false,
       io: { uri: `http://localhost:${port}` }
-    }, {});
+    }, extensions);
     const remoteClone = mockLocal();
     remoteRemotes.setLocal(remoteClone);
     await expect(comesAlive(localRemotes)).resolves.toBe(true);
@@ -64,7 +65,7 @@ describe('Socket.io Remotes', () => {
     localRemotes = new IoRemotes({
       '@id': 'local-remotes', '@domain': domain, genesis: false,
       io: { uri: `http://localhost:${port}` }
-    }, {});
+    }, extensions);
     localRemotes.setLocal(mockLocal());
     const clock = TreeClock.GENESIS.forked().left;
     remoteRemotes.setLocal(mockLocal({
@@ -80,7 +81,7 @@ describe('Socket.io Remotes', () => {
     localRemotes = new IoRemotes({
       '@id': 'local-remotes', '@domain': domain, genesis: false,
       io: { uri: `http://localhost:${port}` }
-    }, {});
+    }, extensions);
     localRemotes.setLocal(mockLocal());
     const remote = new MockProcess(TreeClock.GENESIS.forked().right);
     remoteRemotes.setLocal(mockLocal({

--- a/test/MeldState.test.ts
+++ b/test/MeldState.test.ts
@@ -2,7 +2,7 @@ import {
   any, Construct, Describe, Group, MeldUpdate, Reference, Select, Subject, Update
 } from '../src';
 import { ApiStateMachine } from '../src/engine/MeldState';
-import { memStore, mockRemotes, testConfig, testContext } from './testClones';
+import { memStore, mockRemotes, testConfig, testContext, testExtensions } from './testClones';
 import { DatasetEngine } from '../src/engine/dataset/DatasetEngine';
 import { Future } from '../src/engine/util';
 import { blankRegex, genIdRegex } from './testUtil';
@@ -18,10 +18,11 @@ describe('Meld State API', () => {
   let captureUpdate: Future<MeldUpdate>;
 
   beforeEach(async () => {
+    const ext = { constraints: [new DefaultList('test')] };
     let clone = new DatasetEngine({
       dataset: await memStore({ context: testContext }),
       remotes: mockRemotes(),
-      extensions: { constraints: [new DefaultList('test')] },
+      extensions: testExtensions(ext),
       config: testConfig(),
       app: {},
       context: testContext

--- a/test/MqttRemotes.test.ts
+++ b/test/MqttRemotes.test.ts
@@ -29,7 +29,7 @@ describe('New MQTT remotes', () => {
       '@domain': 'test.m-ld.org',
       genesis: true, // Actually not used by MqttRemotes
       mqtt: { hostname: 'unused' }
-    }, {}, () => mqtt);
+    }, () => Promise.resolve({}), () => mqtt);
   });
 
   test('live starts unknown', async () => {

--- a/test/OrmSubject.test.ts
+++ b/test/OrmSubject.test.ts
@@ -1,0 +1,139 @@
+import { MockGraphState, testContext } from './testClones';
+import { GraphSubject, Optional, Subject, updateSubject } from '../src';
+import { DefaultList } from '../src/constraints/DefaultList';
+import { OrmSubject } from '../src/orm';
+
+describe('Object-RDF Mapping', () => {
+  let state: MockGraphState;
+
+  beforeEach(async () => {
+    state = await MockGraphState.create({ context: testContext });
+  });
+
+  afterEach(() => state.close());
+
+  class Flintstone extends OrmSubject {
+    name: string;
+    height?: number;
+
+    constructor(src: GraphSubject) {
+      super(src);
+      this.initSrcProperty(src, 'name', String,
+        () => this.name, v => this.name = v);
+      this.initSrcProperty(src, 'height', [Optional, Number],
+        () => this.height, (v?: number) => this.height = v);
+    }
+  }
+
+  test('updates a subject string property', async () => {
+    const fredSrc = { '@id': 'fred', name: 'Fred' };
+    await state.write(fredSrc);
+    const fred = new Flintstone(fredSrc);
+    expect(fred.deleted).toBe(false);
+    const update = await state.write({
+      '@delete': fredSrc,
+      '@insert': { '@id': 'fred', name: 'Fred Flintstone' }
+    }, { updateType: 'user' });
+    updateSubject(fred.src, update);
+    expect(fred.deleted).toBe(false);
+    expect(fred.name).toBe('Fred Flintstone');
+  });
+
+  test('source property reflects changes', () => {
+    const fredSrc = { '@id': 'fred', name: 'Fred' };
+    const fred = new Flintstone(fredSrc);
+    fred.name = 'Fred Flintstone';
+    expect(fred.src.name).toBe('Fred Flintstone');
+  });
+
+  test('update rejects if invariant broken', async () => {
+    const fredSrc = { '@id': 'fred', name: 'Fred', height: 6 };
+    await state.write(fredSrc);
+    const fred = new Flintstone(fredSrc);
+    const update = await state.write(
+      { '@delete': { '@id': 'fred', name: 'Fred' } }, { updateType: 'user' });
+    updateSubject(fred.src, update);
+    await expect(fred.updated).rejects.toThrowError(TypeError);
+    // Update failed, so name property unchanged
+    expect(fred.src.name).toBe('Fred');
+    expect(fred.src.height).toBe(6);
+    expect(fred.deleted).toBe(false);
+  });
+
+  test('object is deleted if all properties removed', async () => {
+    const fredSrc = { '@id': 'fred', name: 'Fred', height: 6 };
+    await state.write(fredSrc);
+    const fred = new Flintstone(fredSrc);
+    const update = await state.write({ '@delete': fredSrc }, { updateType: 'user' });
+    updateSubject(fred.src, update);
+    expect(fred.deleted).toBe(true);
+  });
+
+  class EpisodeTitles extends OrmSubject {
+    list: string[] = [];
+
+    constructor(src: GraphSubject) {
+      super(src);
+      this.initList(src, String, this.list,
+        i => this.list[i], (i, v) => this.list[i] = v);
+    }
+  }
+
+  test('updates a list string', async () => {
+    const episodesSrc = { '@id': 'episodes', '@list': ['The Flintstone Flyer'] };
+    const constraint = new DefaultList('test');
+    await state.write(episodesSrc, constraint);
+    const episodes = new EpisodeTitles(episodesSrc);
+    expect(episodes.deleted).toBe(false);
+    let update = await state.write({
+      '@insert': { '@id': 'episodes', '@list': { 1: 'Hot Lips Hannigan' } }
+    }, { updateType: 'user', constraint });
+    updateSubject(episodes.src, update);
+    expect(episodes.list).toEqual(['The Flintstone Flyer', 'Hot Lips Hannigan']);
+    expect(episodes.deleted).toBe(false);
+    update = await state.write({
+      '@delete': { '@id': 'episodes', '@list': { '?': '?' } }
+    }, { updateType: 'user', constraint });
+    updateSubject(episodes.src, update);
+    expect(episodes.list).toEqual([]);
+    expect(episodes.deleted).toBe(true);
+  });
+
+  class Episode extends OrmSubject {
+    title: string;
+
+    constructor(src: GraphSubject, title?: string) {
+      super(src);
+      this.initSrcProperty(src, 'title', String,
+        () => this.title, v => this.title = v, title);
+    }
+  }
+
+  class Episodes extends OrmSubject {
+    list: Episode[] = [];
+
+    constructor(src: GraphSubject) {
+      super(src);
+      this.initList(src, Subject, this.list,
+        i => this.list[i].src, async (i, v: GraphSubject) =>
+          // Here we always load because we don't have an OrmDomain in the test
+          this.list[i] = new Episode((await state.graph.get(v['@id'], state.ctx))!));
+    }
+  }
+
+  test('updates a list subject', async () => {
+    const tff = { '@id': 'tff', title: 'The Flintstone Flyer' };
+    const episodesSrc = { '@id': 'episodes', '@list': [tff] };
+    const constraint = new DefaultList('test');
+    await state.write(episodesSrc, constraint);
+    const episodes = new Episodes(episodesSrc);
+    await episodes.updated;
+    const hlh = { '@id': 'hlh', title: 'Hot Lips Hannigan' };
+    const update = await state.write({
+      '@insert': { '@id': 'episodes', '@list': { 1: hlh } }
+    }, { updateType: 'user', constraint });
+    updateSubject(episodes.src, update);
+    await episodes.updated;
+    expect(episodes.list.map(e => e.src)).toEqual([tff, hlh]);
+  });
+});

--- a/test/SuSetDataset.test.ts
+++ b/test/SuSetDataset.test.ts
@@ -1,5 +1,5 @@
 import { SuSetDataset } from '../src/engine/dataset/SuSetDataset';
-import { MockProcess, MockState, testOp } from './testClones';
+import { MockProcess, MockState, testExtensions, testOp } from './testClones';
 import { GlobalClock, TreeClock } from '../src/engine/clocks';
 import { toArray } from 'rxjs/operators';
 import { EmptyError, firstValueFrom, lastValueFrom, Subject } from 'rxjs';
@@ -48,7 +48,7 @@ describe('SU-Set Dataset', () => {
 
   describe('with basic config', () => {
     beforeEach(async () => {
-      ssd = new SuSetDataset(state.dataset, {}, {}, {}, {
+      ssd = new SuSetDataset(state.dataset, {}, testExtensions(), {}, {
         '@id': 'test',
         '@domain': 'test.m-ld.org'
       });
@@ -565,7 +565,7 @@ describe('SU-Set Dataset', () => {
       };
       ssd = new SuSetDataset(state.dataset,
         {},
-        { constraints: [constraint] }, {},
+        testExtensions({ constraints: [constraint] }), {},
         { '@id': 'test', '@domain': 'test.m-ld.org' });
       await ssd.initialise();
       await ssd.resetClock(local.tick().time);
@@ -759,7 +759,7 @@ describe('SU-Set Dataset', () => {
       remote = new MockProcess(right);
       checkpoints = new Subject<JournalCheckPoint>();
       agreementConditions = [];
-      ssd = new SuSetDataset(state.dataset, {}, { agreementConditions },
+      ssd = new SuSetDataset(state.dataset, {}, testExtensions({ agreementConditions }),
         { journalAdmin: { checkpoints } },
         { '@id': 'test', '@domain': 'test.m-ld.org', journal: { adminDebounce: 0 } });
       await ssd.initialise();
@@ -933,7 +933,7 @@ describe('SU-Set Dataset', () => {
   });
 
   test('enforces operation size limit', async () => {
-    ssd = new SuSetDataset(state.dataset, {}, {}, {}, {
+    ssd = new SuSetDataset(state.dataset, {}, testExtensions(), {}, {
       '@id': 'test',
       '@domain': 'test.m-ld.org',
       maxOperationSize: 1

--- a/test/WritePermitted.test.ts
+++ b/test/WritePermitted.test.ts
@@ -21,7 +21,7 @@ describe('Write permissions', () => {
   test('allows anything if no permissions', async () => {
     const writePermitted = new WritePermitted();
     await writePermitted.initialise(state.graph.asReadState);
-    for (let constraint of writePermitted.constraints)
+    for (let constraint of (await writePermitted.ready()).constraints ?? [])
       await expect(constraint.check(state.graph.asReadState, mockInterim({
         '@ticks': 0,
         '@delete': new SubjectGraph([]),
@@ -37,7 +37,7 @@ describe('Write permissions', () => {
     const writePermitted = new WritePermitted();
     await writePermitted.initialise(state.graph.asReadState);
     expect.hasAssertions();
-    for (let constraint of writePermitted.constraints)
+    for (let constraint of (await writePermitted.ready()).constraints ?? [])
       await expect(constraint.check(state.graph.asReadState, mockInterim({
         '@ticks': 0,
         '@delete': new SubjectGraph([]),
@@ -53,7 +53,7 @@ describe('Write permissions', () => {
     const writePermitted = new WritePermitted();
     await writePermitted.initialise(state.graph.asReadState);
     expect.hasAssertions();
-    for (let constraint of writePermitted.constraints)
+    for (let constraint of (await writePermitted.ready()).constraints ?? [])
       await expect(constraint.check(state.graph.asReadState, mockInterim({
         '@ticks': 0,
         '@delete': new SubjectGraph([]),
@@ -72,7 +72,7 @@ describe('Write permissions', () => {
     const writePermitted = new WritePermitted();
     await writePermitted.initialise(state.graph.asReadState);
     expect.hasAssertions();
-    for (let constraint of writePermitted.constraints)
+    for (let constraint of (await writePermitted.ready()).constraints ?? [])
       await expect(constraint.check(state.graph.asReadState, mockInterim({
         '@principal': { '@id': 'http://test.m-ld.org/hanna' },
         '@ticks': 0,

--- a/test/jsonld.test.ts
+++ b/test/jsonld.test.ts
@@ -54,11 +54,14 @@ describe('JSON-LD', () => {
     expect(getValues({}, 'any')).toEqual([]);
     expect(getValues({ any: null }, 'any')).toEqual([]);
     expect(getValues({ any: undefined }, 'any')).toEqual([]);
+    expect(getValues({ any: { '@set': [] } }, 'any')).toEqual([]);
     expect(getValues({ any: 'any' }, 'any')).toEqual(['any']);
     expect(getValues({ any: ['any'] }, 'any')).toEqual(['any']);
     // Edge case: jsonld library incorrectly skips falsy values
     expect(getValues({ any: '' }, 'any')).toEqual(['']);
     expect(getValues({ any: [0, ''] }, 'any')).toEqual([0, '']);
+    expect(getValues({ any: { '@set': 0 } }, 'any')).toEqual([0]);
+    expect(getValues({ any: { '@set': [0] } }, 'any')).toEqual([0]);
   });
 
   test('compares values', () => {

--- a/test/shacl.test.ts
+++ b/test/shacl.test.ts
@@ -1,5 +1,5 @@
 import { SH } from '../src/ns';
-import { PropertyShape, Shape } from '../src/shacl/index';
+import { PropertyShape, Shape } from '../src/shacl';
 
 describe('SHACL support', () => {
   test('create a property shape from a subject', () => {
@@ -8,14 +8,14 @@ describe('SHACL support', () => {
       [SH.path]: { '@vocab': 'http://test.m-ld.org/#name' }
     });
     expect(shape).toBeInstanceOf(PropertyShape);
-    expect((<PropertyShape>shape).path).toEqual({ '@vocab': 'http://test.m-ld.org/#name' });
+    expect((<PropertyShape>shape).path).toBe('http://test.m-ld.org/#name');
   });
 
   test('create a property shape from just a path', () => {
     const shape = new PropertyShape({ '@id': 'http://test.m-ld.org/nameShape' }, {
-      path: { '@vocab': 'http://test.m-ld.org/#name' }
+      path: 'http://test.m-ld.org/#name'
     });
-    expect((<PropertyShape>shape).path).toEqual({ '@vocab': 'http://test.m-ld.org/#name' });
+    expect((<PropertyShape>shape).path).toBe('http://test.m-ld.org/#name');
   });
 
   test('update the path of a property shape', () => {
@@ -25,13 +25,13 @@ describe('SHACL support', () => {
     });
     // This tests the ability to respond to m-ld updates
     shape.src[SH.path] = { '@vocab': 'http://test.m-ld.org/#height' };
-    expect((<PropertyShape>shape).path).toEqual({ '@vocab': 'http://test.m-ld.org/#height' });
+    expect((<PropertyShape>shape).path).toBe('http://test.m-ld.org/#height');
   });
 
   test('declare a property shape', () => {
     const write = PropertyShape.declare({
       shapeId: 'http://test.m-ld.org/nameShape',
-      path: { '@vocab': 'http://test.m-ld.org/#name' }
+      path: 'http://test.m-ld.org/#name'
     });
     expect(write).toMatchObject({
       '@id': 'http://test.m-ld.org/nameShape',

--- a/test/updates.test.ts
+++ b/test/updates.test.ts
@@ -1,50 +1,51 @@
 import { mockFn } from 'jest-mock-extended';
 import {
   asSubjectUpdates, includesValue, includeValues, Optional, propertyValue, Reference, Subject,
-  updateSubject
+  updateSubject, VocabReference
 } from '../src';
 import { SubjectGraph } from '../src/engine/SubjectGraph';
 import { XS } from '../src/ns';
-import { VocabReference } from '../src/jrql-support';
 
 describe('Update utilities', () => {
-  test('converts simple group update to subject updates', () => {
-    expect(asSubjectUpdates({
-      '@delete': [{ '@id': 'foo', size: 10 }],
-      '@insert': [{ '@id': 'foo', size: 20 }]
-    })).toEqual({
-      'foo': {
-        '@delete': { '@id': 'foo', size: 10 },
-        '@insert': { '@id': 'foo', size: 20 }
-      }
+  describe('by-subject indexing', () => {
+    test('converts simple group update to subject updates', () => {
+      expect(asSubjectUpdates({
+        '@delete': [{ '@id': 'foo', size: 10 }],
+        '@insert': [{ '@id': 'foo', size: 20 }]
+      })).toEqual({
+        'foo': {
+          '@delete': { '@id': 'foo', size: 10 },
+          '@insert': { '@id': 'foo', size: 20 }
+        }
+      });
     });
-  });
 
-  test('un-reifies references in subject updates', () => {
-    expect(asSubjectUpdates({
-      '@delete': [{ '@id': 'foo', friend: { '@id': 'bar', name: 'Bob' } }],
-      '@insert': []
-    })).toEqual({
-      'foo': {
-        '@delete': { '@id': 'foo', friend: { '@id': 'bar' } },
-        '@insert': undefined
-      }
+    test('un-reifies references in subject updates', () => {
+      expect(asSubjectUpdates({
+        '@delete': [{ '@id': 'foo', friend: { '@id': 'bar', name: 'Bob' } }],
+        '@insert': []
+      })).toEqual({
+        'foo': {
+          '@delete': { '@id': 'foo', friend: { '@id': 'bar' } },
+          '@insert': undefined
+        }
+      });
     });
-  });
 
-  test('converts array group update to subject updates', () => {
-    expect(asSubjectUpdates({
-      '@delete': [{ '@id': 'foo', size: 10 }, { '@id': 'bar', size: 30 }],
-      '@insert': [{ '@id': 'foo', size: 20 }, { '@id': 'bar', size: 40 }]
-    })).toEqual({
-      'foo': {
-        '@delete': { '@id': 'foo', size: 10 },
-        '@insert': { '@id': 'foo', size: 20 }
-      },
-      'bar': {
-        '@delete': { '@id': 'bar', size: 30 },
-        '@insert': { '@id': 'bar', size: 40 }
-      }
+    test('converts array group update to subject updates', () => {
+      expect(asSubjectUpdates({
+        '@delete': [{ '@id': 'foo', size: 10 }, { '@id': 'bar', size: 30 }],
+        '@insert': [{ '@id': 'foo', size: 20 }, { '@id': 'bar', size: 40 }]
+      })).toEqual({
+        'foo': {
+          '@delete': { '@id': 'foo', size: 10 },
+          '@insert': { '@id': 'foo', size: 20 }
+        },
+        'bar': {
+          '@delete': { '@id': 'bar', size: 30 },
+          '@insert': { '@id': 'bar', size: 40 }
+        }
+      });
     });
   });
 
@@ -79,6 +80,18 @@ describe('Update utilities', () => {
     expect(box.label).toEqual({ '@set': ['My Box', 'Your Box'] });
   });
 
+  test('remove set values in subject', () => {
+    // Using a plain Subject here because Box doesn't admit a label @set
+    const box = { '@id': 'bar', size: 10, label: { '@set': 'My Box' } };
+    updateSubject(box, {
+      bar: {
+        '@delete': { '@id': 'bar', label: 'My Box' },
+        '@insert': undefined
+      }
+    });
+    expect(box.label).toEqual({ '@set': [] });
+  });
+
   test('includes value in subject', () => {
     const box: Box = { '@id': 'bar', size: 10, label: 'My Box' };
     expect(includesValue(box, 'label', 'My Box')).toBe(true);
@@ -100,8 +113,8 @@ describe('Update utilities', () => {
     const box: Box = { '@id': 'foo', size: 10 };
     updateSubject(box, {
       foo: {
-        '@insert': { '@id': 'foo', label: 'My box' },
-        '@delete': undefined
+        '@delete': undefined,
+        '@insert': { '@id': 'foo', label: 'My box' }
       }
     });
     expect(box).toEqual({ '@id': 'foo', size: 10, label: 'My box' });
@@ -111,8 +124,8 @@ describe('Update utilities', () => {
     const box: Box = { '@id': 'foo', size: 10 };
     updateSubject(box, {
       foo: {
-        '@insert': { '@id': 'foo', size: [20, 30] },
-        '@delete': undefined
+        '@delete': undefined,
+        '@insert': { '@id': 'foo', size: [20, 30] }
       }
     });
     expect(box).toEqual({ '@id': 'foo', size: [10, 20, 30] });
@@ -128,8 +141,8 @@ describe('Update utilities', () => {
     const box = { '@id': 'foo', size: [10, 20] };
     updateSubject(box, {
       foo: {
-        '@insert': undefined,
-        '@delete': { '@id': 'foo', size: [10, 20] }
+        '@delete': { '@id': 'foo', size: [10, 20] },
+        '@insert': undefined
       }
     });
     expect(box).toEqual({ '@id': 'foo' });
@@ -163,8 +176,8 @@ describe('Update utilities', () => {
     const box: Box = { '@id': 'foo', size: 10, label: 'My box' };
     updateSubject(box, {
       foo: {
-        '@insert': { '@id': 'foo', size: 20 },
-        '@delete': { '@id': 'foo', size: 10 }
+        '@delete': { '@id': 'foo', size: 10 },
+        '@insert': { '@id': 'foo', size: 20 }
       }
     });
     expect(box).toEqual({ '@id': 'foo', size: 20, label: 'My box' });
@@ -174,8 +187,8 @@ describe('Update utilities', () => {
     const box: Box = { '@id': 'foo', size: 10, label: 'My box' };
     updateSubject(box, {
       foo: {
-        '@insert': { '@id': 'foo', size: 10 },
-        '@delete': { '@id': 'foo', size: 10 }
+        '@delete': { '@id': 'foo', size: 10 },
+        '@insert': { '@id': 'foo', size: 10 }
       }
     });
     expect(box).toEqual({ '@id': 'foo', size: 10, label: 'My box' });
@@ -211,6 +224,54 @@ describe('Update utilities', () => {
       }
     });
     expect(box).toEqual({ '@id': 'foo', size: 10, contents: [{ '@id': 'baz' }] });
+  });
+
+  describe('with defined properties', () => {
+    let changed: boolean;
+    const box = Object.defineProperty({ '@id': 'foo' }, 'size', {
+      get: () => 10,
+      set: () => changed = true,
+      enumerable: true
+    });
+
+    beforeEach(() => {
+      changed = false;
+    });
+
+    test('invokes setter if value added', () => {
+      updateSubject(box, {
+        foo: { '@delete': undefined, '@insert': { '@id': 'foo', size: 11 } }
+      });
+      expect(changed).toBe(true);
+    });
+
+    test('invokes setter if value removed', () => {
+      updateSubject(box, {
+        foo: { '@delete': { '@id': 'foo', size: 10 }, '@insert': undefined }
+      });
+      expect(changed).toBe(true);
+    });
+
+    test('does not invoke setter on irrelevant change', () => {
+      updateSubject(box, {
+        bar: { '@delete': undefined, '@insert': { '@id': 'bar', size: 100 } }
+      });
+      expect(changed).toBe(false);
+    });
+
+    test('does not invoke setter if same value added', () => {
+      updateSubject(box, {
+        foo: { '@delete': undefined, '@insert': { '@id': 'foo', size: 10 } }
+      });
+      expect(changed).toBe(false);
+    });
+
+    test('does not invoke setter if unmatched value removed', () => {
+      updateSubject(box, {
+        foo: { '@delete': { '@id': 'foo', size: 11 }, '@insert': undefined }
+      });
+      expect(changed).toBe(false);
+    });
   });
 
   describe('Deep updates', () => {


### PR DESCRIPTION
Refactored provers to receive a graph update filtered to affected shapes rather than the affected shapes themselves.
Refactored CloneExtensions to use ORM & new ExtensionSubject class
ORM supports for Lists, fixes and tests
Made extension access async to allow for use of extensions during update processing

In support of m-ld/m-ld-security-spec#3 task "Externally-driven authorisation"