### PR TITLE
Add `NullRemotes`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "./ext/socket.io-server": "./ext/socket.io/server/index.js",
     "./ext/socket.io/server": "./ext/socket.io/server/index.js",
     "./ext/ably": "./ext/ably/index.js",
+    "./ext/null": "./ext/null/index.js",
     "./ext/html": "./ext/html/index.js",
     "./ext/wrtc": "./ext/wrtc/index.js",
     "./ext/security": "./ext/security/index.js",

--- a/src/null/NullRemotes.ts
+++ b/src/null/NullRemotes.ts
@@ -1,0 +1,41 @@
+import { NEVER, type Observable, concat, of } from "rxjs";
+
+import { MeldRemotes, OperationMessage, MeldLocal } from "../engine";
+import type { LiveValue } from '../engine/api-support';
+
+class NotImplementedError extends Error {
+  constructor(methodName: string) {
+    super(
+      `${methodName} is not implemented for a NullRemote. The local clone should be genesis.`
+    );
+  }
+}
+
+const constantLiveValue = <T>(value: T): LiveValue<T> => {
+  // Emit `value`, then never complete.
+  const observable = concat(of(value), NEVER);
+  return Object.defineProperty(observable, "value", {
+    value,
+    writable: false,
+  }) as unknown as LiveValue<T>;
+};
+
+export class NullRemotes implements MeldRemotes {
+  readonly operations: Observable<OperationMessage> = NEVER;
+  readonly updates: Observable<OperationMessage> = NEVER;
+  readonly live: LiveValue<boolean | null> = constantLiveValue(false);
+
+  setLocal(_clone: MeldLocal | null): void {}
+
+  newClock(): never {
+    throw new NotImplementedError("newClock");
+  }
+
+  revupFrom(): never {
+    throw new NotImplementedError("revupFrom");
+  }
+
+  snapshot(): never {
+    throw new NotImplementedError("snapshot");
+  }
+}

--- a/src/null/NullRemotes.ts
+++ b/src/null/NullRemotes.ts
@@ -1,4 +1,4 @@
-import { NEVER, type Observable, concat, of } from "rxjs";
+import { BehaviorSubject, NEVER, type Observable } from "rxjs";
 
 import { MeldRemotes, OperationMessage, MeldLocal } from "../engine";
 import type { LiveValue } from '../engine/api-support';
@@ -11,19 +11,10 @@ class NotImplementedError extends Error {
   }
 }
 
-const constantLiveValue = <T>(value: T): LiveValue<T> => {
-  // Emit `value`, then never complete.
-  const observable = concat(of(value), NEVER);
-  return Object.defineProperty(observable, "value", {
-    value,
-    writable: false,
-  }) as unknown as LiveValue<T>;
-};
-
 export class NullRemotes implements MeldRemotes {
   readonly operations: Observable<OperationMessage> = NEVER;
   readonly updates: Observable<OperationMessage> = NEVER;
-  readonly live: LiveValue<boolean | null> = constantLiveValue(false);
+  readonly live: LiveValue<boolean | null> = new BehaviorSubject(false);
 
   setLocal(_clone: MeldLocal | null): void {}
 

--- a/src/null/index.ts
+++ b/src/null/index.ts
@@ -1,0 +1,1 @@
+export { NullRemotes } from './NullRemotes';


### PR DESCRIPTION
I've just discovered I can't define this ad hoc elsewhere, because it needs access to `/engine`, which isn't exposed outside of the project through `exports` in `package.json`.

@gsvarovsky What would you say to pulling it in now?